### PR TITLE
Fixup piping in camelize

### DIFF
--- a/lib/crutches/string.ex
+++ b/lib/crutches/string.ex
@@ -9,12 +9,10 @@ defmodule Crutches.String do
   end
 
   def camelize(underscore) do
-    array = underscore
+    underscore
     |> String.split("_")
-    |> Enum.map fn(word) -> String.capitalize(word) end
-    array |> Enum.reduce fn(x, acc) ->  acc <> x end
-    #Not sure why we can't use the pipe directly from
-    #Enum.map, but it throws an error.
+    |> Enum.map(&String.capitalize(&1))
+    |> Enum.reduce(&(&2 <> &1))
   end
 
   #Switch parameter order so we can use the pipe operator.


### PR DESCRIPTION
I noticed your code comment and figured I'd send a PR to help with that.

Basically you should use parens when piping. It will help Elixir to
understand the order of things better.

This also uses the capture syntax for the anonymous functions.
