### PR TITLE
Add Crutches.List.to function

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ ActiveSupport has some great goodies that are useful in web application developm
 * remove
 
 #### List
-* without
 * from
-* to_sentence
 * shorten
+* to
+* to_sentence
+* without
 
 ### License
 MIT

--- a/README.md
+++ b/README.md
@@ -20,16 +20,17 @@ ActiveSupport has some great goodies that are useful in web application developm
 ### Current Methods Available
 
 #### String
-* underscore
 * camelize
 * from
-* to
-* squish
 * remove
+* squish
+* to
+* underscore
 
 #### List
 * from
 * shorten
+* split
 * to
 * to_sentence
 * without

--- a/lib/crutches/list.ex
+++ b/lib/crutches/list.ex
@@ -168,4 +168,26 @@ defmodule Crutches.List do
   def shorten([head | tail], amount) when length(tail) > amount do
     [head | shorten(tail, amount)]
   end
+
+  @doc ~S"""
+  Returns a copy of the List from the beginning to the required index.
+
+  ## Examples
+
+      iex> List.to(["a", "b", "c"], 0)
+      ["a"]
+
+      iex> List.to(["a", "b", "c"], 1)
+      ["a", "b"]
+
+      iex> List.to(["a", "b", "c"], 20)
+      ["a", "b", "c"]
+
+      iex> List.to(["a", "b", "c"], -1)
+      []
+  """
+  @spec to(t, i) :: t
+  def to(collection, position) do
+    if position >= 0, do: Enum.take(collection, position + 1), else: []
+  end
 end

--- a/lib/crutches/list.ex
+++ b/lib/crutches/list.ex
@@ -222,15 +222,10 @@ defmodule Crutches.List do
   defp do_split(collection, x) when is_function(x) do
     Stream.map(collection, fn(k) -> {x.(k), k} end)
       |>  Enum.reduce({[], []}, fn
-             {true, elem}, {head, acc} -> {[], [Enum.reverse(head) | acc]}
+            {true,  _},    {head, acc} -> {[], [Enum.reverse(head) | acc]}
             {false, elem}, {head, acc} -> {[elem | head], acc}
           end)
   end
 
-  defp do_split(collection, x) do
-    Enum.reduce(collection, {[], []}, fn
-      elem, {head, acc} when elem == x -> {[], [Enum.reverse(head) | acc]}
-      elem, {head, acc} -> {[elem | head], acc}
-    end)
-  end
+  defp do_split(collection, x), do: do_split(collection, fn(k) -> k == x end)
 end

--- a/lib/crutches/list.ex
+++ b/lib/crutches/list.ex
@@ -1,6 +1,7 @@
 defmodule Crutches.List do
   @type t :: List
   @type i :: Integer
+  @type a :: any
 
   @doc ~S"""
   Returns a copy of the List without the specified elements.
@@ -189,5 +190,47 @@ defmodule Crutches.List do
   @spec to(t, i) :: t
   def to(collection, position) do
     if position >= 0, do: Enum.take(collection, position + 1), else: []
+  end
+
+  @doc ~S"""
+  Return a List containing the original List splitted by an element or by a
+  function.
+
+  ## Examples
+
+      iex> List.split(["a", "b", "c", "d", "c", "e"], "c")
+      [["a", "b"], ["d"], ["e"]]
+
+      iex> List.split(["c", "a", "b"], "c")
+      [[], ["a", "b"]]
+
+      iex> List.split([], 1)
+      [[]]
+
+      iex> List.split([1, 2, 3, 4, 5, 6, 7, 8], fn(x) -> rem(x, 2) == 0 end)
+      [[1], [3], [5], [7], []]
+
+      iex> List.split(1..15, &(rem(&1,3) == 0))
+      [[1, 2], [4, 5], [7, 8], [10 , 11], [13, 14], []]
+  """
+  @spec split(t, any) :: t
+  def split(collection, x) do
+    {head, acc} = do_split(collection, x)
+    Enum.reverse(acc, [Enum.reverse(head)])
+  end
+
+  defp do_split(collection, x) when is_function(x) do
+    Stream.map(collection, fn(k) -> {x.(k), k} end)
+      |>  Enum.reduce({[], []}, fn
+             {true, elem}, {head, acc} -> {[], [Enum.reverse(head) | acc]}
+            {false, elem}, {head, acc} -> {[elem | head], acc}
+          end)
+  end
+
+  defp do_split(collection, x) do
+    Enum.reduce(collection, {[], []}, fn
+      elem, {head, acc} when elem == x -> {[], [Enum.reverse(head) | acc]}
+      elem, {head, acc} -> {[elem | head], acc}
+    end)
   end
 end

--- a/lib/crutches/string.ex
+++ b/lib/crutches/string.ex
@@ -84,22 +84,22 @@ defmodule Crutches.String do
       ""
 
   You can mix it with +to+ method and do fun things like:
-      iex> str = "hello"
+      iex> "hello"
       iex> |> String.from(0)
       iex> |> String.to(-1)
       "hello"
 
-      iex> str = "hello"
+      iex> "hello"
       iex> |> String.from(1)
       iex> |> String.to(-2)
       "ell"
 
-      iex> str = "a"
+      iex> "a"
       iex> |> String.from(1)
       iex> |> String.to(1500)
       ""
 
-      iex> str = "elixir"
+      iex> "elixir"
       iex> |> String.from(-10)
       iex> |> String.to(-7)
       ""
@@ -132,12 +132,12 @@ defmodule Crutches.String do
       "hell"
 
   You can mix it with +from+ method and do fun things like:
-      iex> str = "hello"
+      iex> "hello"
       iex> |> String.from(0)
       iex> |> String.to(-1)
       "hello"
 
-      iex> str = "hello"
+      iex> "hello"
       iex> |> String.from(1)
       iex> |> String.to(-2)
       "ell"


### PR DESCRIPTION
I implemented Array#to. However, Array#to as some unexpected (to me) behaviour when dealing with negative indexes. 

``` ruby
> x = %w[1 2 3 4 ]
> x.to(-1)
[]
> x.to(-2)
ArgumentError: negative array size
```

So, my choice has been to deal with negative indexes in a different way. A negative index never throw an exception, but give back an empty array. Initially I thought of take from the back of the array, but the Array#from method do exactly this, and I didn't want to mix things. Obviously, I'm open to changes!

Thank you again for this _dojo_ for learning Elixir. :+1: 
