### PR TITLE
Improve the project's general documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,35 +1,62 @@
 # How to contribute
 
-Contribute with... ([code](#contribute-with-code)|[documentation](#contribute-with-documentation)|[ideas](#contribute-with-ideas)|[discussion](#contribute-with-discussion))
+First off, thank you for taking the time to check out how to contribute! It is
+greatly appreciated.  You can contribute with [code], [documentation], [bug
+reports], [discussion] and [ideas and feature requests].
 
-## Summary
+ [code]:#contribute-with-code
+ [documentation]:#contribute-with-documentation
+ [bug reports]:#bug-reports
+ [ideas and feature requests]:#contribute-with-ideas
+ [discussion]:#contribute-with-discussion
 
-There are various way you can contribute to this project, and this document will
-help you through the process of figuring out how _you_ could contribute. If you
-need a more in depth document, go to the wiki, were there will be an article on
-how to create your first contribution, with each step detailed.
+If you need more in depth information about how exactly you can get started,
+head to the wiki. There is an article under construction that'll help you with
+contributing towards your first issue, from beginning to end.
+
+## Bug reports
+
+Good bug reports go a long way to make this library more stable and easy to use
+for anyone. If you spot a bug, please *do* report it, but also include the
+following information to make it easier to reproduce the issue:
+
+ - Your Erlang/OTP and Elixir version.
+ - Your OS and version.
+ - The version (or commit SHA) of Crutches.
+
+Before reporting a bug, please also check:
+
+ - If the issue has been reported before. Don't worry if you're not 100% sure,
+   we prefer dealing with duplicate issues than unreported bugs.
+ - If it has been fixed in `master`.
 
 ## Contribute with code
 
- * Choose an issue to implement. Issues are marked on their perceived difficulty
-   level
- * Comment on the issue, letting the others know you are working on the issue.
- * Fork this repository!
- * Adapt the pseudo-documentation to the proper Elixir format, adding doctests
- * Assure that the test are working launching `mix test` in the shell
- * Make the test pass, writing the necessary code
- * Open a Pull Request
+ - Choose an issue to implement. Issues are marked on their perceived difficulty
+   level. Comment on it, letting the others know you are working on it.
+ - Fork this repository and clone your fork to your local machine!
+ - Create a new branch with a descriptive name.
+ - Follow the instructions on the issue. Adapt the function documentation you
+   find in the issue to the Elixir format (ExDoc). Be sure to add the doctests.
+ - Write the code to make the tests pass. You can check this by typing `mix test`
+   in your shell.
+ - Commit, push and open a Pull Request!
 
-**Bonus Points**:
+### Bonus points
 
-Those points are not necessary, but helpful on improving the quality of the code
-and the overall quality of this repository.
+Extra internet points are awarded for the following things. These are not
+necessary, but they improve the quality of the code and the overall quality
+of this repository.
 
- * Try to follow the [Elixir Style Guide](https://github.com/niftyn8/elixir_style_guide)
- * Rebase your code before submitting a Pull Request and squash the commits in
-   a single commit
- * Write a proper commit message. [Here](https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message)
-   you could find a description on how to make a proper commit message.
+ - Try to follow the [Elixir style guide].
+ - Use `git`'s interactive rebase tool before submitting a Pull Request to
+   squash the commits into a single commit.
+ - Rebase the `master` branch into your own, ensuring that your changes can
+   be merged cleanly.
+ - Write a [proper commit message].
+
+ [proper commit message]:https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
+ [Elixir style guide]:https://github.com/niftyn8/elixir_style_guide
 
 ## Contribute with documentation
 
@@ -37,6 +64,12 @@ Documentation is a first class citizen in Elixir. So treat it like a first class
 citizen! If you see a general lack of documentation, or you simply want to
 contribute but you are not still able to write Elixir code, you could always
 improve the documentation.
+
+If you want some pointers for places that the documentation could be improved
+upon, check the [Inch CI page] of the project. Anything below an A might
+need some work.
+
+ [Inch CI page]:http://inch-ci.org/github/mykewould/crutches
 
 ## Contribute with ideas
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Michael Wood and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,52 +1,57 @@
-[![Build Status](https://travis-ci.org/mykewould/crutches.svg?branch=master)](https://travis-ci.org/mykewould/crutches)
-[![Inline docs](http://inch-ci.org/github/mykewould/crutches.svg?branch=master)](http://inch-ci.org/github/mykewould/crutches)
-
 Crutches
 =======
 
-The start of an Elixir ~~ripoff~~ port to the [ActiveSupport Ruby gem](https://github.com/rails/rails/tree/master/activesupport).
+[![Build Status](https://travis-ci.org/mykewould/crutches.svg?branch=master)](https://travis-ci.org/mykewould/crutches)
+[![Inline docs](http://inch-ci.org/github/mykewould/crutches.svg?branch=master)](http://inch-ci.org/github/mykewould/crutches)
 
-Do you want to contribute? Take a look at `CONTRIBUTING.md`!
+This is the start of an Elixir port of the [ActiveSupport Rubygem]. [Contributions
+welcome].
 
-### [Documentation](http://hexdocs.pm/crutches/)
+ [ActiveSupport Rubygem]:https://github.com/rails/rails/tree/master/activesupport
+ [Contributions welcome]:https://github.com/mykewould/crutches#new-to-elixir
 
-### New to Elixir, and coming from Ruby?
+Contributions are especially welcomed! Take a look at `[CONTRIBUTING.md]` for
+more information.
 
-This library is a great for Elixir beginners to contribute to. By porting over
-ActiveSupport most of the documentation and specs have been written for the
-methods. This allows the contributor to focus on the syntax and nuances of
-Elixir. The bonus here is that the contributor will be helping an open source
-project while learning the basics.
+### Compatability and versioning
 
-### Why ActiveSupport?
+We test against the following combinations of Erlang/OTP and Elixir. Other
+combinations are not officially supported.
+
+ - Erlang/OTP `18.0` and Elixir `1.0.5`
+
+This project is still alpha software. APIs and supported Elixir and/or Erlang
+versions may change at a moments notice. Use with discretion.
+
+### Documentation
+
+The following places contain documentation on Crutches:
+
+ - [API reference] on Hexdocs, the standard Elixir documentation hoster.
+ - [Wiki]&mdash;still under construction.
+
+ [API reference]:http://hexdocs.pm/crutches/
+ [Wiki]:https://github.com/mykewould/crutches/wiki
+
+### New to Elixir?
+
+This library is a great for Elixir beginners to contribute to. We are porting
+over ActiveSupport, an addition to the standard library of the Ruby programming
+language. Most of the function documentation and specs have been written already.
+This allows the contributor to focus on the syntax and nuances of Elixir. The
+bonus here is that the contributor will be helping an open source project while
+learning the basics.
+
+Take a look at `[CONTRIBUTING.md]` for more information on how you can get
+started.
+
+ [CONTRIBUTING.md]:https://github.com/mykewould/crutches/blob/master/CONTRIBUTING.md
+
+#### Why ActiveSupport?
 
 ActiveSupport has some great goodies that are useful in web application
 development. Furthermore the design pattern for ActiveSupport, and it's use
 cases, are not hard to understand. If you are coming from the Rails community,
-being a contributor on this project shouldn't be overly difficult.
+being a contributor on this project shouldn't be overly difficult. And if you're
+not, just give it a try!
 
-### License
-
-```
-The MIT License (MIT)
-
-Copyright (c) 2015 Michael Wood
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```


### PR DESCRIPTION
Hey everyone,

Did some work on the README and assorted files when I was offline. Here are the changes from my commit message:
- **Maybe needs discussion:** Worded the contributing pitch to also target others who are not coming from the Ruby world.
- Moved the licensing information to it's own file.
- Noted the Elixir and Erlang/OTP versions that we currently test against.
- Added a notice about the library being a moving target and not stable yet.
- Link to the wiki as well as the API reference.
- Moved the buttons down below the title.
- Added a thank you note in `CONTRIBUTING.md`
- 'Refactored' the links in `CONTRIBUTING.md`
- Clarify and consolidate the step by step guide on code contributions
- Changed the wording in the contributing bonus points section a bit
- Added a pointer to Inch CI in the contributing documentation section
- Add section on bug reports to `CONTRIBUTING.md`

Everything is up for debate of course. Especially the first point is something that could be up for debate.

Let me know what you think!
