### PR TITLE
WIP Dialyzer fixes

### DIFF
--- a/lib/crutches/enum.ex
+++ b/lib/crutches/enum.ex
@@ -1,9 +1,4 @@
 defmodule Crutches.Enum do
-  @type b :: Boolean
-  @type a :: Any
-  @type l :: List
-  @type m :: Map
-
   @doc ~S"""
   Returns a copy of the Enum without the specified elements.
 
@@ -21,7 +16,7 @@ defmodule Crutches.Enum do
       iex > Enum.without([ answer: 42 ], [:answer])
       []
   """
-  @spec without(l, l) :: l
+  @spec without(list(any), list(any)) :: list(any)
   def without(collection, elements) when is_list(collection) do
     if Keyword.keyword? collection do
       Keyword.drop collection, elements
@@ -30,7 +25,7 @@ defmodule Crutches.Enum do
     end
   end
 
-  @spec without(m, l) :: m
+  @spec without(map, list(any)) :: map
   def without(collection, elements) when is_map(collection) do
     Map.drop collection, elements
   end
@@ -58,11 +53,11 @@ defmodule Crutches.Enum do
       iex> Enum.many?([ answer: 42 ])
       false
   """
-  @spec many?(l) :: b
+  @spec many?(list(any)) :: boolean
   def many?([]), do: false
-  def many?([ head | tail ]), do: !Enum.empty?(tail)
+  def many?([head | tail]), do: !Enum.empty?(tail)
 
-  @spec many?(m) :: b
+  @spec many?(map) :: boolean
   def many?(%{}), do: false
   def many?(collection) when is_map(collection), do: Map.size(collection) > 1
 end

--- a/lib/crutches/integer.ex
+++ b/lib/crutches/integer.ex
@@ -1,6 +1,6 @@
 defmodule Crutches.Integer do
-  @type s :: String
-  @type i :: Integer
+  @type s :: String.t()
+  @type i :: integer
 
   @doc ~S"""
   Return _just_ the ordinal of a number ("st", "nd", "rd", "th")

--- a/lib/crutches/integer.ex
+++ b/lib/crutches/integer.ex
@@ -1,7 +1,4 @@
 defmodule Crutches.Integer do
-  @type s :: String.t()
-  @type i :: integer
-
   @doc ~S"""
   Return _just_ the ordinal of a number ("st", "nd", "rd", "th")
 
@@ -19,7 +16,7 @@ defmodule Crutches.Integer do
       iex> Integer.ordinal(-23)
       "rd"
   """
-  @spec ordinal(i) :: s
+  @spec ordinal(integer) :: String.t
   def ordinal(n) when is_integer(n) do
     case n |> to_string |> String.slice(-1, 1) do
       "1" -> "st"
@@ -43,7 +40,7 @@ defmodule Crutches.Integer do
       iex> Integer.ordinalize(-8)
       "-8th"
   """
-  @spec ordinalize(i) :: s
+  @spec ordinalize(integer) :: String.t
   def ordinalize(n) when is_integer(n), do: to_string(n) <> ordinal(n)
 
   @doc ~S"""
@@ -60,5 +57,6 @@ defmodule Crutches.Integer do
       iex> Integer.multiple_of?(14, 7)
       true
   """
+  @spec multiple_of?(integer, integer) :: boolean
   def multiple_of?(n, divisor), do: rem(n, divisor) == 0
 end

--- a/lib/crutches/list.ex
+++ b/lib/crutches/list.ex
@@ -236,7 +236,7 @@ defmodule Crutches.List do
       [["1", "2", "3", "4"], ["5", "6", "7"], ["8", "9", "10"]]
 
   """
-  @spec in_groups(list(any), integer, any, (() -> any)) :: list(any)
+  @spec in_groups(list(any), integer, any, (any -> any)) :: list(any)
   def in_groups(collection, number, elem, fun) do
     in_groups(collection, number, elem)
     |> Enum.map(fun)

--- a/lib/crutches/list.ex
+++ b/lib/crutches/list.ex
@@ -1,8 +1,4 @@
 defmodule Crutches.List do
-  @type t :: List
-  @type i :: Integer
-  @type a :: any
-
   @doc ~S"""
   Returns the tail of the array from +position+.
 
@@ -28,7 +24,7 @@ defmodule Crutches.List do
       []
 
   """
-  @spec from(t, i) :: t
+  @spec from(list(any), integer) :: list(any)
   def from(collection, position) do
     Enum.slice(collection, position, length(collection))
   end
@@ -108,7 +104,7 @@ defmodule Crutches.List do
     ]
   ]
 
-  @spec to_sentence(t) :: String.t
+  @spec to_sentence(list(any)) :: String.t
   def to_sentence(words, options \\ [])
   def to_sentence([],     _), do: ""
   def to_sentence([word], _), do: "#{word}"
@@ -153,7 +149,7 @@ defmodule Crutches.List do
       iex> List.shorten([5, 6, 7, 8], 5)
       nil
   """
-  @spec shorten(t, integer) :: t
+  @spec shorten(list(any), integer) :: list(any)
   def shorten(list, amount \\ 1)
   def shorten(list, amount) when length(list) < amount, do: nil
   def shorten(list, amount) when length(list) == amount, do: []
@@ -179,7 +175,7 @@ defmodule Crutches.List do
       iex> List.to(["a", "b", "c"], -1)
       []
   """
-  @spec to(t, i) :: t
+  @spec to(list(any), integer) :: list(any)
   def to(collection, position) do
     if position >= 0, do: Enum.take(collection, position + 1), else: []
   end
@@ -205,7 +201,7 @@ defmodule Crutches.List do
       iex> List.split(1..15, &(rem(&1,3) == 0))
       [[1, 2], [4, 5], [7, 8], [10 , 11], [13, 14], []]
   """
-  @spec split(t, any) :: t
+  @spec split(list(any), any) :: list(any)
   def split(collection, x) do
     {head, acc} = do_split(collection, x)
     Enum.reverse(acc, [Enum.reverse(head)])
@@ -240,7 +236,7 @@ defmodule Crutches.List do
       [["1", "2", "3", "4"], ["5", "6", "7"], ["8", "9", "10"]]
 
   """
-  @spec in_groups(t, i, Any, Fun) :: t
+  @spec in_groups(list(any), integer, any, (() -> any)) :: list(any)
   def in_groups(collection, number, elem, fun) do
     in_groups(collection, number, elem)
     |> Enum.map(fun)

--- a/lib/crutches/string.ex
+++ b/lib/crutches/string.ex
@@ -8,8 +8,6 @@ defmodule Crutches.String do
     strip: 1
   ]
 
-  @type s :: String.t
-
   @doc ~S"""
   Makes an underscored, lowercase form from the expression in the string.
   +underscore+ will also change '.' to '/' to convert namespaces to paths.
@@ -33,7 +31,7 @@ defmodule Crutches.String do
       ["UsersSection.Commission.Department", "users_section/commission/department"],
 
   """
-  @spec underscore(s) :: s
+  @spec underscore(String.t) :: String.t
   def underscore(camel_case) do
     camel_case
     |> replace(~r/\./, "/")
@@ -61,7 +59,7 @@ defmodule Crutches.String do
       "Area51Controller"
 
   """
-  @spec camelize(s) :: s
+  @spec camelize(String.t) :: String.t
   def camelize(underscore) do
     underscore
     |> split("_")
@@ -109,7 +107,7 @@ defmodule Crutches.String do
       iex> |> String.to(-7)
       ""
   """
-  @spec from(s, Integer.t) :: s
+  @spec from(String.t, integer) :: String.t
   def from(string, start) when start >= 0 do
     slice(string, start..(String.length(string) - 1))
   end
@@ -147,7 +145,7 @@ defmodule Crutches.String do
       iex> |> String.to(-2)
       "ell"
   """
-  @spec to(s, Integer.t) :: s
+  @spec to(String.t, integer) :: String.t
   def to(string, length) when length >= 0 do
     slice(string, 0..length)
   end
@@ -173,7 +171,7 @@ defmodule Crutches.String do
       iex> String.squish(str)
       "foo bar boo"
   """
-  @spec squish(s) :: s
+  @spec squish(String.t) :: String.t
   def squish(string) do
     string |> replace(~r/[[:space:]]+/, " ") |> strip
   end
@@ -191,7 +189,7 @@ defmodule Crutches.String do
       iex> String.remove("foo bar test", [~r/foo /, " test"])
       "bar"
   """
-  @spec remove(s, s | Regex.t | List.t) :: s
+  @spec remove(String.t, String.t | Regex.t | List.t) :: String.t
   def remove(string, to_remove) when is_list(to_remove) do
     to_remove |> Enum.reduce(string, &remove(&2, &1))
   end

--- a/lib/crutches/string.ex
+++ b/lib/crutches/string.ex
@@ -189,7 +189,7 @@ defmodule Crutches.String do
       iex> String.remove("foo bar test", [~r/foo /, " test"])
       "bar"
   """
-  @spec remove(String.t, String.t | Regex.t | List.t) :: String.t
+  @spec remove(String.t, String.t | Regex.t | list(any)) :: String.t
   def remove(string, to_remove) when is_list(to_remove) do
     to_remove |> Enum.reduce(string, &remove(&2, &1))
   end

--- a/lib/crutches/string.ex
+++ b/lib/crutches/string.ex
@@ -8,7 +8,8 @@ defmodule Crutches.String do
     strip: 1
   ]
 
-  @type t :: String
+  @type s :: String.t
+
   @doc ~S"""
   Makes an underscored, lowercase form from the expression in the string.
   +underscore+ will also change '.' to '/' to convert namespaces to paths.
@@ -32,7 +33,7 @@ defmodule Crutches.String do
       ["UsersSection.Commission.Department", "users_section/commission/department"],
 
   """
-  @spec underscore(t) :: t
+  @spec underscore(s) :: s
   def underscore(camel_case) do
     camel_case
     |> replace(~r/\./, "/")
@@ -60,7 +61,7 @@ defmodule Crutches.String do
       "Area51Controller"
 
   """
-  @spec camelize(t) :: t
+  @spec camelize(s) :: s
   def camelize(underscore) do
     underscore
     |> split("_")
@@ -108,7 +109,7 @@ defmodule Crutches.String do
       iex> |> String.to(-7)
       ""
   """
-  @spec from(t, Integer.t) :: t
+  @spec from(s, Integer.t) :: s
   def from(string, start) when start >= 0 do
     slice(string, start..(String.length(string) - 1))
   end
@@ -146,7 +147,7 @@ defmodule Crutches.String do
       iex> |> String.to(-2)
       "ell"
   """
-  @spec to(t, Integer.t) :: t
+  @spec to(s, Integer.t) :: s
   def to(string, length) when length >= 0 do
     slice(string, 0..length)
   end
@@ -172,7 +173,7 @@ defmodule Crutches.String do
       iex> String.squish(str)
       "foo bar boo"
   """
-  @spec squish(t) :: t
+  @spec squish(s) :: s
   def squish(string) do
     string |> replace(~r/[[:space:]]+/, " ") |> strip
   end
@@ -190,7 +191,7 @@ defmodule Crutches.String do
       iex> String.remove("foo bar test", [~r/foo /, " test"])
       "bar"
   """
-  @spec remove(t, t | Regex.t | List.t) :: t
+  @spec remove(s, s | Regex.t | List.t) :: s
   def remove(string, to_remove) when is_list(to_remove) do
     to_remove |> Enum.reduce(string, &remove(&2, &1))
   end


### PR DESCRIPTION
Hi all,

I wanted to get this WIP out there and ask for a bit of help/feedback before I move on with this.

I am trying to make sure that Dialyzer, the succes typing tool for the BEAM, is giving us the all green. There were some errors in the typespecs when running the tool. Here is the original output when I started:

```
Starting Dialyzer
dialyzer --no_check_plt --plt /Users/duijf/.dialyxir_core_17_1.0.3.plt -Wunmatched_returns -Werror_handling -Wrace_conditions -Wunderspecs /Users/duijf/src/active/crutches/_build/dev/lib/crutches/ebin
  Proceeding with analysis...
enum.ex:61: Invalid type specification for function 'Elixir.Crutches.Enum':'many?'/1. The success typing is (maybe_improper_list() | #{}) -> boolean()
integer.ex:22: Invalid type specification for function 'Elixir.Crutches.Integer':ordinal/1. The success typing is (integer()) -> <<_:16>>
integer.ex:46: Invalid type specification for function 'Elixir.Crutches.Integer':ordinalize/1. The success typing is (integer()) -> binary()
list.ex:31: Invalid type specification for function 'Elixir.Crutches.List':from/2. The success typing is ([any()],integer()) -> [any()]
list.ex:111: Invalid type specification for function 'Elixir.Crutches.List':to_sentence/1. The success typing is ([any()]) -> binary()
list.ex:156: Invalid type specification for function 'Elixir.Crutches.List':shorten/2. The success typing is ([any()],_) -> 'nil' | maybe_improper_list(any(),'nil' | [])
list.ex:182: Invalid type specification for function 'Elixir.Crutches.List':to/2. The success typing is (_,_) -> [any()]
list.ex:208: Invalid type specification for function 'Elixir.Crutches.List':split/2. The success typing is (_,_) -> [any()]
list.ex:243: Invalid type specification for function 'Elixir.Crutches.List':in_groups/4. The success typing is ([any()],integer(),_,fun((_) -> any())) -> [any()]
string.ex:35: Invalid type specification for function 'Elixir.Crutches.String':underscore/1. The success typing is (binary()) -> binary()
string.ex:63: Invalid type specification for function 'Elixir.Crutches.String':camelize/1. The success typing is (binary()) -> any()
string.ex:111: Invalid type specification for function 'Elixir.Crutches.String':from/2. The success typing is (binary(),_) -> binary()
string.ex:149: Invalid type specification for function 'Elixir.Crutches.String':to/2. The success typing is (binary(),_) -> binary()
string.ex:175: Invalid type specification for function 'Elixir.Crutches.String':squish/1. The success typing is (binary()) -> binary()
Unknown types:
  'Elixir.Integer':t/0
  'Elixir.List':t/0
 done in 0m1.07s
done (warnings were emitted)
```

With the code changes, we get zero warnings:

```
Starting Dialyzer
dialyzer --no_check_plt --plt /Users/duijf/.dialyxir_core_17_1.0.3.plt -Wunmatched_returns -Werror_handling -Wrace_conditions -Wunderspecs /Users/duijf/src/active/crutches/_build/dev/lib/crutches/ebin
  Proceeding with analysis... done in 0m1.06s
done (passed successfully)
```

To get this far, I've removed all of the type aliases (they were confusing me a lot). These can be added in again after all this is done.

I'd love feedback/opinions on the following:
- Is it even worthwhile it to pursue this?
- ~~Can someone more well versed in these matters tell me why `List.in_groups` doesn't typecheck? I guess it is an invalid `@spec` but I can't see the issue.~~
- Did I correct the other errors in the right way or did I simply silence them?

After this is figured out, I'll squash and rebase.

Cheers,
Laurens
