### PR TITLE
Add Travis webhook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,13 @@ elixir:
 
 notifications:
   email: false
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/0152272011bece7f993c
+    on_success: change
+    on_failure: always
+    on_start: false
+
 
 after_script:
   - MIX_ENV=docs mix deps.get


### PR DESCRIPTION
This adds Travis build notifications to the Gitter chat.
