### PR TITLE
Inefficient List.shorten

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /deps
 erl_crash.dump
 *.ez
+/bench/snapshots

--- a/bench/list_bench.exs
+++ b/bench/list_bench.exs
@@ -1,0 +1,9 @@
+defmodule Crutches.ListBench do
+  use Benchfella
+
+  @list 1..2000 |> Enum.to_list
+
+  bench "shorten/2" do
+    Crutches.List.shorten @list, 1500
+  end
+end

--- a/bench/list_bench.exs
+++ b/bench/list_bench.exs
@@ -3,7 +3,7 @@ defmodule Crutches.ListBench do
 
   @list 1..2000 |> Enum.to_list
 
-  bench "shorten/2" do
+  bench "shorten/2 2000 by 1500" do
     Crutches.List.shorten @list, 1500
   end
 end

--- a/lib/crutches/list.ex
+++ b/lib/crutches/list.ex
@@ -158,11 +158,14 @@ defmodule Crutches.List do
   """
   @spec shorten(list(any), integer) :: list(any)
   def shorten(list, amount \\ 1)
-  def shorten(list, amount) when length(list) < amount, do: nil
-  def shorten(list, amount) when length(list) == amount, do: []
-  def shorten([head | tail], amount) when length(tail) == amount, do: [head]
-  def shorten([head | tail], amount) when length(tail) > amount do
-    [head | shorten(tail, amount)]
+  def shorten(list, amount) do
+    shorten(list, amount, length(list))
+  end
+  defp shorten(list, amount, len) when len < amount do
+    nil
+  end
+  defp shorten(list, amount, len) do
+    Enum.take(list, len - amount)
   end
 
   @doc ~S"""

--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,7 @@ defmodule Crutches.Mixfile do
      description: "An Elixir toolbelt freely inspired from Ruby's ActiveSupport",
      package: [contributors: ["Michael Wood", "Kash Nouroozi", "Maurizio Del Corno",
                               "nawns", "Laurens Duijvesteijn", "Joel Meador",
-                              "Sonny Scroggin"],
+                              "Sonny Scroggin", "Louis Pilfold"],
                licenses: ["MIT"],
                links: %{"GitHub" => "https://github.com/mykewould/crutches"}]]
   end
@@ -33,8 +33,9 @@ defmodule Crutches.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:inch_ex, only: :docs},
-     {:ex_doc,  only: :docs},
-     {:earmark, only: :docs}]
+    [{:inch_ex,    only: :docs},
+     {:ex_doc,     only: :docs},
+     {:earmark,    only: :docs},
+     {:benchfella, only: :dev}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"earmark": {:hex, :earmark, "0.1.17"},
+%{"benchfella": {:hex, :benchfella, "0.2.1"},
+  "earmark": {:hex, :earmark, "0.1.17"},
   "ex_doc": {:hex, :ex_doc, "0.8.3"},
   "inch_ex": {:hex, :inch_ex, "0.4.0-dev"},
   "poison": {:hex, :poison, "1.4.0"}}


### PR DESCRIPTION
Hello!

I couldn't help but notice that `Crutches.List.shorten/2` is currently extremely inefficient.

To resolve this I've added a benchmark for this function, and then rewritten it. I think it's a lot easier to read now too. :)

Cheers,
Louis
## Benchmark results

When shortening a list of 2000 elements by 1500...

Before
shorten/2         500   4213.86 µs/op

After
shorten/2      100000   12.93 µs/op

Diff
shorten/2    -99.69%
