### PR TITLE
New range functions and improvement on existing ones

### DIFF
--- a/lib/crutches/range.ex
+++ b/lib/crutches/range.ex
@@ -55,7 +55,7 @@ defmodule Crutches.Range do
     false
   """
   @spec contiguous?(Range.t, Range.t) :: boolean
-  def contiguous?(range1, range2) do
+  def contiguous?(_.._=range1, _.._=range2) do
     a..b = sort(range1)
     x..y = sort(range2)
     if (b + 1 == x) or (y + 1 == a) do
@@ -94,7 +94,7 @@ defmodule Crutches.Range do
       5..5
   """
   @spec intersection(Range.t, Range.t) :: Range.t | nil
-  def intersection(range1, range2) do
+  def intersection(_.._=range1, _.._=range2) do
     if overlaps?(range1, range2) do
       a..b = sort(range1)
       x..y = sort(range2)
@@ -182,7 +182,7 @@ defmodule Crutches.Range do
       1..6
   """
   @spec union(Range.t, Range.t) :: Range.t | nil
-  def union(range1, range2) do
+  def union(_.._=range1, _.._=range2) do
     if overlaps?(range1, range2) or contiguous?(range1, range2) do
       a..b = sort(range1)
       x..y = sort(range2)

--- a/lib/crutches/range.ex
+++ b/lib/crutches/range.ex
@@ -75,20 +75,17 @@ defmodule Crutches.Range do
       iex> Range.intersection(1..5, 4..8)
       4..5
 
-      iex> Range.intersection(1..4, 4..8)
-      4..4
-
       iex> Range.intersection(-1..4, -3..8)
       -1..4
 
-      iex> Range.intersection(1..5, 6..8)
-      nil
-
-      iex> Range.intersection(5..3, 2..4)
-      3..4
+      iex> Range.intersection(1..4, 4..8)
+      4..4
 
       iex> Range.intersection(5..5, 5..5)
       5..5
+
+      iex> Range.intersection(1..5, 6..8)
+      nil
   """
   @spec intersection(Range.t, Range.t) :: Range.t | nil
   def intersection(range1, range2)
@@ -115,12 +112,6 @@ defmodule Crutches.Range do
       true
 
       iex> Range.overlaps?(1..5, 7..9)
-      false
-
-      iex> Range.overlaps?(-1..-5, -4..-6)
-      true
-
-      iex> Range.overlaps?(-1..-5, -7..-9)
       false
 
       iex> Range.overlaps?(5..1, 6..4)
@@ -164,9 +155,6 @@ defmodule Crutches.Range do
 
       iex> Range.sort(0..10, :descending)
       10..0
-
-      iex> Range.sort(10..0, :descending)
-      10..0
   """
   @spec sort(Range.t, :ascending | :descending) :: Range.t
   def sort(range, order \\ :ascending)
@@ -190,20 +178,11 @@ defmodule Crutches.Range do
 
   ## Examples
 
-      iex> Range.union(1..5, 4..8)
-      1..8
-
-      iex> Range.union(-1..8, -3..4)
-      -3..8
-
       iex> Range.union(1..3, 4..6)
       1..6
 
-      iex> Range.union(1..1, 2..2)
-      1..2
-
-      iex> Range.union(1..3, 3..6)
-      1..6
+      iex> Range.union(1..5, 4..8)
+      1..8
 
       iex> Range.union(3..6, 1..3)
       1..6

--- a/lib/crutches/range.ex
+++ b/lib/crutches/range.ex
@@ -26,10 +26,10 @@ defmodule Crutches.Range do
     do: false
 
   @doc """
-  Determines if two ranges are contiguos.
+  Determines if two ranges are contiguous.
 
   Note that the order of the limits does not matter to determine whether the ranges are contiguous
-  or not (eg. `1..3` and `4..6` are contiguos, same as `3..1` and `4..6`).
+  or not (eg. `1..3` and `4..6` are contiguous, same as `3..1` and `4..6`).
 
   If the ranges overlap each other, it will return `false`.
 
@@ -52,7 +52,7 @@ defmodule Crutches.Range do
       false
   """
   @spec contiguous?(Range.t, Range.t) :: boolean
-  def contiguous?(_.._=range1, _.._=range2) do
+  def contiguous?(_.._ = range1, _.._ = range2) do
     a..b = sort(range1)
     x..y = sort(range2)
     if (b + 1 == x) or (y + 1 == a) do
@@ -89,11 +89,11 @@ defmodule Crutches.Range do
   """
   @spec intersection(Range.t, Range.t) :: Range.t | nil
   def intersection(range1, range2)
-  def intersection(a..b=range1, x..y=_range2) when (a == x and b == y) or (a == y and b == x) do
+  def intersection(a..b = range1, x..y = _range2) when (a == x and b == y) or (a == y and b == x) do
     sort(range1)
   end
 
-  def intersection(_.._=range1, _.._=range2) do
+  def intersection(_.._ = range1, _.._ = range2) do
     if overlaps?(range1, range2) do
       a..b = sort(range1)
       x..y = sort(range2)
@@ -164,7 +164,7 @@ defmodule Crutches.Range do
     last..first
   end
 
-  def sort(_first.._last=range, order) when order in [:ascending, :descending] do
+  def sort(_first.._last = range, order) when order in [:ascending, :descending] do
     range
   end
 
@@ -189,11 +189,11 @@ defmodule Crutches.Range do
   """
   @spec union(Range.t, Range.t) :: Range.t | nil
   def union(range1, range2)
-  def union(a..b=range1, x..y=_range2) when (a == x and b == y) or (a == y and b == x) do
+  def union(a..b = range1, x..y = _range2) when (a == x and b == y) or (a == y and b == x) do
     sort(range1)
   end
 
-  def union(_.._=range1, _.._=range2) do
+  def union(_.._ = range1, _.._ = range2) do
     if overlaps?(range1, range2) or contiguous?(range1, range2) do
       a..b = sort(range1)
       x..y = sort(range2)

--- a/lib/crutches/range.ex
+++ b/lib/crutches/range.ex
@@ -69,6 +69,11 @@ defmodule Crutches.Range do
       5..5
   """
   @spec intersection(Range.t, Range.t) :: Range.t | nil
+  def intersection(range1, range2)
+  def intersection(a..b=range1, x..y=_range2) when (a == x and b == y) or (a == y and b == x) do
+    sort(range1)
+  end
+
   def intersection(_.._=range1, _.._=range2) do
     if overlaps?(range1, range2) do
       a..b = sort(range1)
@@ -182,6 +187,11 @@ defmodule Crutches.Range do
       1..6
   """
   @spec union(Range.t, Range.t) :: Range.t | nil
+  def union(range1, range2)
+  def union(a..b=range1, x..y=_range2) when (a == x and b == y) or (a == y and b == x) do
+    sort(range1)
+  end
+
   def union(_.._=range1, _.._=range2) do
     if overlaps?(range1, range2) or contiguous?(range1, range2) do
       a..b = sort(range1)

--- a/lib/crutches/range.ex
+++ b/lib/crutches/range.ex
@@ -4,7 +4,7 @@ defmodule Crutches.Range do
   """
 
   @doc ~S"""
-  Compare two ranges and see if they overlap each other
+  Compare two ranges and see if they overlap each other.
 
   ## Examples
 
@@ -24,69 +24,79 @@ defmodule Crutches.Range do
     true
   """
   @spec overlaps?(Range.t, Range.t) :: boolean
-  def overlaps?(a..b, x..y) do
-    a in x..y || b in x..y || x in a..b || y in a..b
+  def overlaps?(a..b = range1, x.._ = range2) do
+    (a in range2) or (b in range2) or (x in range1)
   end
 
-
   @doc ~S"""
-  Returns the intersection of two ranges, or nil if there is no intersection.
+  Returns a range containing the range shared in common between `range1` and
+  `range2`.
+  Returns `nil` if there is no intersection.
+
   Note that the returned range, if any, will always be in ascending order (the
   first element is <= the last element).
 
   ## Examples
 
-    iex> Range.intersection(1..5, 4..8)
-    4..5
+      iex> Range.intersection(1..5, 4..8)
+      4..5
 
-    iex> Range.intersection(1..4, 4..8)
-    4..4
+      iex> Range.intersection(1..4, 4..8)
+      4..4
 
-    iex> Range.intersection(-1..4, -3..8)
-    -1..4
+      iex> Range.intersection(-1..4, -3..8)
+      -1..4
 
-    iex> Range.intersection(1..5, 6..8)
-    nil
+      iex> Range.intersection(1..5, 6..8)
+      nil
 
-    iex> Range.intersection(5..3, 2..4)
-    3..4
+      iex> Range.intersection(5..3, 2..4)
+      3..4
+
+      iex> Range.intersection(5..5, 5..5)
+      5..5
   """
   @spec intersection(Range.t, Range.t) :: Range.t | nil
-  def intersection(range_1, range_2) do
-    if overlaps?(range_1, range_2) do
-      a..b = normalize_order(range_1)
-      x..y = normalize_order(range_2)
+  def intersection(range1, range2) do
+    if overlaps?(range1, range2) do
+      a..b = normalize_order(range1)
+      x..y = normalize_order(range2)
       max(a, x)..min(b, y)
     else
       nil
     end
   end
 
-
   @doc ~S"""
-  Returns the union of two ranges, or nil if there is no union.
-  Note that the returned range, if any, will always be in ascending order (the
-  first element is <= the last element).
+  Returns the union of two ranges, or `nil` if there is no union.
+
+  A union the represented by the smallest element and the biggest integers in
+  both ranges, provided that they overlap.
+  
+  Note that the returned range, if any, will be in ascending order.
 
   ## Examples
 
-    iex> Range.union(1..5, 4..8)
-    1..8
+      iex> Range.union(1..5, 4..8)
+      1..8
 
-    iex> Range.union(-3..4, -1..8)
-    -3..8
+      iex> Range.union(-1..8, -3..4)
+      -3..8
 
-    iex> Range.union(1..3, 4..6)
-    nil
+      iex> Range.union(1..3, 4..6)
+      nil
 
-    iex> Range.union(1..3, 3..6)
-    1..6
+      iex> Range.union(1..3, 3..6)
+      1..6
+
+      iex> Range.union(3..6, 1..3)
+      1..6
   """
   @spec union(Range.t, Range.t) :: Range.t | nil
-  def union(range_1, range_2) do
-    if overlaps?(range_1, range_2) do
-      a..b = normalize_order(range_1)
-      x..y = normalize_order(range_2)
+  def union(range1, range2) do
+    if overlaps?(range1, range2) do
+      a..b = normalize_order(range1)
+      x..y = normalize_order(range2)
       min(a, x)..max(b, y)
     else
       nil

--- a/lib/crutches/range.ex
+++ b/lib/crutches/range.ex
@@ -3,32 +3,7 @@ defmodule Crutches.Range do
   Convenience functions for ranges.
   """
 
-  @doc ~S"""
-  Determines if two ranges overlap each other.
-
-  ## Examples
-
-    iex> Range.overlaps?(1..5, 4..6)
-    true
-
-    iex> Range.overlaps?(1..5, 7..9)
-    false
-
-    iex> Range.overlaps?(-1..-5, -4..-6)
-    true
-
-    iex> Range.overlaps?(-1..-5, -7..-9)
-    false
-
-    iex> Range.overlaps?(5..1, 6..4)
-    true
-  """
-  @spec overlaps?(Range.t, Range.t) :: boolean
-  def overlaps?(a..b = range1, x.._ = range2) do
-    (a in range2) or (b in range2) or (x in range1)
-  end
-
-  @doc ~S"""
+  @doc """
   Determines if two ranges are contiguos.
 
   Note that the order of the limits does not matter to determine whether the ranges are contiguous
@@ -38,21 +13,21 @@ defmodule Crutches.Range do
 
   ## Examples
 
-    iex> Range.contiguous?(1..4, 5..8)
-    true
+      iex> Range.contiguous?(1..4, 5..8)
+      true
 
-    iex> Range.contiguous?(1..4, 0..-4)
-    true
+      iex> Range.contiguous?(1..4, 0..-4)
+      true
 
-    # Ranges overlap
-    iex> Range.contiguous?(1..4, 0..1)
-    false
+      # Ranges overlap
+      iex> Range.contiguous?(1..4, 0..1)
+      false
 
-    iex> Range.contiguous?(1..4, 6..8)
-    false
+      iex> Range.contiguous?(1..4, 6..8)
+      false
 
-    iex> Range.contiguous?(1..5, 4..8)
-    false
+      iex> Range.contiguous?(1..5, 4..8)
+      false
   """
   @spec contiguous?(Range.t, Range.t) :: boolean
   def contiguous?(_.._=range1, _.._=range2) do
@@ -65,7 +40,7 @@ defmodule Crutches.Range do
     end
   end
 
-  @doc ~S"""
+  @doc """
   Returns a range containing the range shared in common between `range1` and
   `range2`.
   Returns `nil` if there is no intersection.
@@ -105,6 +80,31 @@ defmodule Crutches.Range do
   end
 
   @doc """
+  Determines if two ranges overlap each other.
+
+  ## Examples
+
+      iex> Range.overlaps?(1..5, 4..6)
+      true
+
+      iex> Range.overlaps?(1..5, 7..9)
+      false
+
+      iex> Range.overlaps?(-1..-5, -4..-6)
+      true
+
+      iex> Range.overlaps?(-1..-5, -7..-9)
+      false
+
+      iex> Range.overlaps?(5..1, 6..4)
+      true
+  """
+  @spec overlaps?(Range.t, Range.t) :: boolean
+  def overlaps?(a..b = range1, x.._ = range2) do
+    (a in range2) or (b in range2) or (x in range1)
+  end
+
+  @doc """
   Swaps the order of the first and last limits in the range.
 
   ## Examples
@@ -129,17 +129,17 @@ defmodule Crutches.Range do
 
   ## Examples
 
-    iex> Range.sort(0..10)
-    0..10
+      iex> Range.sort(0..10)
+      0..10
 
-    iex> Range.sort(10..0)
-    0..10
+      iex> Range.sort(10..0)
+      0..10
 
-    iex> Range.sort(0..10, :descending)
-    10..0
+      iex> Range.sort(0..10, :descending)
+      10..0
 
-    iex> Range.sort(10..0, :descending)
-    10..0
+      iex> Range.sort(10..0, :descending)
+      10..0
   """
   @spec sort(Range.t, :ascending | :descending) :: Range.t
   def sort(range, order \\ :ascending)
@@ -153,7 +153,7 @@ defmodule Crutches.Range do
     range
   end
 
-  @doc ~S"""
+  @doc """
   Returns the union of two ranges, or `nil` if there is no union.
 
   A union the represented by the smallest element and the biggest integers in

--- a/lib/crutches/range.ex
+++ b/lib/crutches/range.ex
@@ -4,6 +4,28 @@ defmodule Crutches.Range do
   """
 
   @doc """
+  Determines if two ranges are congruent (i.e. that both cover the same range, regardless the order
+  of their limits).
+
+  ## Examples:
+
+      iex> Range.congruent?(1..5, 5..1)
+      true
+
+      iex> Range.congruent?(1..5, 1..5)
+      true
+
+      iex> Range.congruent?(1..5, 2..5)
+      false
+  """
+  @spec congruent?(Range.t, Range.t) :: boolean
+  def congruent?(range1, range2)
+  def congruent?(a..b, x..y) when (a == x and b == y) or (a == y and b == x),
+    do: true
+  def congruent?(_.._, _.._),
+    do: false
+
+  @doc """
   Determines if two ranges are contiguos.
 
   Note that the order of the limits does not matter to determine whether the ranges are contiguous

--- a/lib/crutches/range.ex
+++ b/lib/crutches/range.ex
@@ -56,8 +56,8 @@ defmodule Crutches.Range do
   """
   @spec contiguous?(Range.t, Range.t) :: boolean
   def contiguous?(range1, range2) do
-    a..b = normalize_order(range1)
-    x..y = normalize_order(range2)
+    a..b = sort(range1)
+    x..y = sort(range2)
     if (b + 1 == x) or (y + 1 == a) do
       true
     else
@@ -96,12 +96,61 @@ defmodule Crutches.Range do
   @spec intersection(Range.t, Range.t) :: Range.t | nil
   def intersection(range1, range2) do
     if overlaps?(range1, range2) do
-      a..b = normalize_order(range1)
-      x..y = normalize_order(range2)
+      a..b = sort(range1)
+      x..y = sort(range2)
       max(a, x)..min(b, y)
     else
       nil
     end
+  end
+
+  @doc """
+  Swaps the order of the first and last limits in the range.
+
+  ## Examples
+
+    iex> Range.reverse(0..10)
+    10..0
+
+    iex> Range.reverse(10..0)
+    0..10
+  """
+  @spec reverse(Range.t) :: Range.t
+  def reverse(range)
+  def reverse(first..last) do
+    last..first
+  end
+
+  @doc """
+  Sorts the `range` by the given `order`.
+
+  `order` can take either `:ascending` or `:descending`.
+  If no `order` is specified, `:ascending` order is used.
+
+  ## Examples
+
+    iex> Range.sort(0..10)
+    0..10
+
+    iex> Range.sort(10..0)
+    0..10
+
+    iex> Range.sort(0..10, :descending)
+    10..0
+
+    iex> Range.sort(10..0, :descending)
+    10..0
+  """
+  @spec sort(Range.t, :ascending | :descending) :: Range.t
+  def sort(range, order \\ :ascending)
+
+  def sort(first..last, order)
+  when (order == :ascending and first > last) or (order == :descending and last > first) do
+    last..first
+  end
+
+  def sort(_first.._last=range, order) when order in [:ascending, :descending] do
+    range
   end
 
   @doc ~S"""
@@ -109,7 +158,7 @@ defmodule Crutches.Range do
 
   A union the represented by the smallest element and the biggest integers in
   both ranges, provided that the ranges overlap or are contiguous.
-  
+
   Note that the returned range, if any, will be in ascending order.
 
   ## Examples
@@ -135,18 +184,11 @@ defmodule Crutches.Range do
   @spec union(Range.t, Range.t) :: Range.t | nil
   def union(range1, range2) do
     if overlaps?(range1, range2) or contiguous?(range1, range2) do
-      a..b = normalize_order(range1)
-      x..y = normalize_order(range2)
+      a..b = sort(range1)
+      x..y = sort(range2)
       min(a, x)..max(b, y)
     else
       nil
     end
   end
-
-  # Private helper function that flips a range's order so that it's ascending.
-  @spec normalize_order(Range.t) :: Range.t
-  defp normalize_order(first..last) when first > last,
-    do: last..first
-  defp normalize_order(range),
-    do: range
 end

--- a/test/crutches/range_test.exs
+++ b/test/crutches/range_test.exs
@@ -2,4 +2,174 @@ defmodule Crutches.RangeTest do
   alias Crutches.Range
   use ExUnit.Case, async: true
   doctest Crutches.Range
+
+  test "congruent?/2" do
+    assert Range.congruent?(1..4, 1..4)
+    assert Range.congruent?(1..4, 4..1)
+    assert Range.congruent?(4..4, 4..4)
+    assert Range.congruent?(4..4, 4..4)
+
+    refute Range.congruent?(1..4, 5..8)
+    refute Range.congruent?(1..4, -1..-4)
+    refute Range.congruent?(1..4, 1..5)
+    refute Range.congruent?(0..4, 1..5)
+    refute Range.congruent?(4..4, 3..3)
+  end
+
+  test "contiguous?/2" do
+    assert Range.contiguous?(1..4, 5..8)
+    assert Range.contiguous?(1..4, 0..-4)
+    assert Range.contiguous?(1..4, -4..0)
+
+    # Overlaping ranges
+    refute Range.contiguous?(4..4, 4..4)
+    refute Range.contiguous?(0..1, 1..4)
+    refute Range.contiguous?(0..2, 1..4)
+    refute Range.contiguous?(2..4, 4..2)
+
+    # Not touching
+    refute Range.contiguous?(1..4, 6..8)
+    refute Range.contiguous?(1..4, -1..-4)
+    refute Range.contiguous?(1..4, -4..-1)
+  end
+
+  test "intersection/2" do
+    assert Range.intersection(1..5, 4..8) == 4..5
+    assert Range.intersection(5..1, 4..8) == 4..5
+    assert Range.intersection(1..5, 8..4) == 4..5
+    assert Range.intersection(5..1, 8..4) == 4..5
+
+    assert Range.intersection(1..4, 4..8) == 4..4
+    assert Range.intersection(4..1, 4..8) == 4..4
+    assert Range.intersection(1..4, 8..4) == 4..4
+    assert Range.intersection(4..1, 8..4) == 4..4
+
+    assert Range.intersection(-1..4, -3..8) == -1..4
+    assert Range.intersection(-1..4, -3..3) == -1..3
+
+    # same ranges
+    assert Range.intersection(4..4, 4..4) == 4..4
+    assert Range.intersection(4..-1, 4..-1) == -1..4
+    assert Range.intersection(-1..4, -1..4) == -1..4
+    assert Range.intersection(4..-1, -1..4) == -1..4
+    assert Range.intersection(-1..4, 4..-1) == -1..4
+
+    # contiguous ranges
+    assert Range.intersection(0..1, 2..3) == nil
+    assert Range.intersection(0..1, 3..2) == nil
+    assert Range.intersection(1..1, 2..2) == nil
+
+    # Not touching
+    assert Range.intersection(1..4, 6..8) == nil
+    assert Range.intersection(1..4, -1..-4) == nil
+    assert Range.intersection(1..4, -4..-1) == nil
+  end
+
+  test "overlaps?/2" do
+    assert Range.overlaps?(4..4, 4..4)
+    assert Range.overlaps?(0..1, 1..4)
+    assert Range.overlaps?(0..2, 1..4)
+    assert Range.overlaps?(2..4, 4..2)
+
+    # Contiguous
+    refute Range.overlaps?(1..4, 5..8)
+    refute Range.overlaps?(1..4, 0..-4)
+    refute Range.overlaps?(1..4, -4..0)
+
+    # Not touching
+    refute Range.overlaps?(1..4, 6..8)
+    refute Range.overlaps?(1..4, -1..-4)
+    refute Range.overlaps?(1..4, -4..-1)
+  end
+
+  test "reverse/1" do
+    assert Range.reverse(1..5) == 5..1
+    assert Range.reverse(5..5) == 5..5
+    assert Range.reverse(-5..1) == 1..-5
+  end
+
+  test "sort/2" do
+    assert Range.sort(1..5) == 1..5
+    assert Range.sort(5..1) == 1..5
+    assert Range.sort(5..5) == 5..5
+    assert Range.sort(-1..-5) == -5..-1
+    assert Range.sort(-5..-1) == -5..-1
+    assert Range.sort(-1..-5, :ascending) == -5..-1
+    assert Range.sort(-5..-1, :ascending) == -5..-1
+
+    assert Range.sort(1..5, :descending) == 5..1
+    assert Range.sort(5..1, :descending) == 5..1
+    assert Range.sort(5..5, :descending) == 5..5
+    assert Range.sort(-1..-5, :descending) == -1..-5
+    assert Range.sort(-5..-1, :descending) == -1..-5
+
+    assert_raise FunctionClauseError, fn ->
+      Range.sort([1, 2, 3, 4], :descending)
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      Range.sort(1..5, "descending")
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      Range.sort(1..5, :asc)
+    end
+  end
+
+  test "union/2" do
+    assert Range.union(1..5, 4..8) == 1..8
+    assert Range.union(5..1, 4..8) == 1..8
+    assert Range.union(1..5, 8..4) == 1..8
+    assert Range.union(5..1, 8..4) == 1..8
+
+    assert Range.union(1..4, 4..8) == 1..8
+    assert Range.union(4..1, 4..8) == 1..8
+    assert Range.union(1..4, 8..4) == 1..8
+    assert Range.union(4..1, 8..4) == 1..8
+
+    assert Range.union(-1..4, -3..8) == -3..8
+    assert Range.union(-1..4, -3..3) == -3..4
+
+    # same ranges
+    assert Range.union(4..4, 4..4) == 4..4
+    assert Range.union(4..-1, 4..-1) == -1..4
+    assert Range.union(-1..4, -1..4) == -1..4
+    assert Range.union(4..-1, -1..4) == -1..4
+    assert Range.union(-1..4, 4..-1) == -1..4
+
+    # contiguous ranges
+    assert Range.union(2..3, 0..1) == 0..3
+    assert Range.union(3..2, 0..1) == 0..3
+    assert Range.union(1..1, 2..2) == 1..2
+
+    # Not touching
+    assert Range.union(1..4, 6..8) == nil
+    assert Range.union(1..4, -1..-4) == nil
+    assert Range.union(1..4, -4..-1) == nil
+  end
+
+  test "invalid arguments" do
+    list = [1, 2, 3, 4]
+    range = 5..8
+
+    # arity 1
+    for f <- [:reverse, :sort] do
+      assert_raise FunctionClauseError, fn ->
+        apply(Range, f, [list])
+      end
+    end
+
+    # arity 2
+    for f <- [:congruent?, :contiguous?, :intersection, :overlaps?, :union] do
+      assert_raise FunctionClauseError, fn ->
+        apply(Range, f, [list, range])
+      end
+      assert_raise FunctionClauseError, fn ->
+        apply(Range, f, [range, list])
+      end
+      assert_raise FunctionClauseError, fn ->
+        apply(Range, f, [list, list])
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds new functions to Range.
- `Range.congruent?/2`
- `Range.contiguous?/2`
- `Range.sort/2`
- `Range.reverse/1`

Removed:
- `Range.normalize_order/1` (replaced by `Range.sort/2`)

Improvements: 
- `Range.overlaps?/2`: use `or` instead of `||`. and check only for three conditions, since the fourth one is not necessary
- `Range.union/2`: corrected to deal with ranges that are contiguous (Enum.union/2 behaves the same way)
- union/2 and intersection/2 optimized 
- Pattern matching improved in all functions. If not range is given the function won't match
- Docs improved
- IEx examples properly indented with 4 spaces.
- Tests written for each function in Range module.
