### PR TITLE
Add simple is_prime? method to Integer

### DIFF
--- a/lib/crutches/integer.ex
+++ b/lib/crutches/integer.ex
@@ -21,6 +21,30 @@ defmodule Crutches.Integer do
   @spec multiple_of?(integer, integer) :: boolean
   def multiple_of?(n, divisor) when is_integer(n), do: rem(n, divisor) == 0
 
+  @doc ~S"""
+  Check if integer is a prime number.
+
+  # Example
+      iex> Integer.is_prime?(2)
+      true
+
+      iex> Integer.is_prime?(4)
+      false
+
+      iex> Integer.is_prime?(7)
+      true
+  """
+  def is_prime?(int) do
+    is_prime?(int, 2, :math.sqrt(int))
+  end
+  def is_prime?(int, divisor, limit) when divisor > limit, do: true
+  def is_prime?(int, divisor, limit) do
+    cond do
+      rem(int, divisor) === 0 -> false
+      true -> is_prime?(int, divisor + 1, limit)
+    end
+  end
+
   @doc """
   Returns the ordered digits for the given non-negative integer.
 


### PR DESCRIPTION
Addresses #100 

It currently expects an integer param to be passed in and it returns
true or false whether the value is prime or not.

Currently not doing any check of any kind. It could be extended to do a
little more checks and fail a little more gracefully maybe.
