### PR TITLE
Changed shorten to return tagged tuple when the length is shorter than the amount

### DIFF
--- a/lib/crutches/format/list.ex
+++ b/lib/crutches/format/list.ex
@@ -75,7 +75,12 @@ defmodule Crutches.Format.List do
   def as_sentence(words, opts) when is_list(words) do
     opts = Option.combine!(opts, @as_sentence)
 
-    init = Crutches.List.shorten(words) |> Enum.join(opts[:words_connector])
+    init =
+      case Crutches.List.shorten(words) do
+        {:ok, shortened_list} -> Enum.join(shortened_list, opts[:words_connector])
+        _ -> []
+      end
+      
     last = List.last(words)
 
     init <> opts[:last_word_connector] <> last

--- a/lib/crutches/list.ex
+++ b/lib/crutches/list.ex
@@ -44,23 +44,25 @@ defmodule Crutches.List do
   ## Examples
 
       iex> List.shorten(["one", "two", "three"], 2)
-      ["one"]
+      {:ok, ["one"]}
 
       iex> List.shorten([5, 6], 2)
-      []
+      {:ok, []}
 
       iex> List.shorten([5, 6, 7, 8], 5)
-      nil
+      {:error, "Amount to shorten by is greater than the length of the list"}
   """
   @spec shorten(list(any), integer) :: list(any)
-  def shorten(list, amount \\ 1)
-  def shorten(list, amount) do
+  def shorten(list, amount \\ 1) do
     shorten(list, amount, length(list))
   end
 
-  defp shorten(_, amount, len) when len < amount, do: nil
+  defp shorten(_, amount, len) when len < amount, 
+  do: {:error, "Amount to shorten by is greater than the length of the list"}
+  
   defp shorten(list, amount, len) do
-    Enum.take(list, len - amount)
+    shortened_list = Enum.take(list, len - amount)
+    {:ok, shortened_list}
   end
 
   @doc ~S"""


### PR DESCRIPTION
Implementation for https://github.com/mykewould/crutches/issues/94. 
- As @duijf mentioned, we will return a tagged tuple instead of nil (in the scenario that the user passes an `amount < len(list)`). 
- I also delegated the ok function to @knrz's Towel library.
