### PR TITLE
Remove various warnings with Elixir 1.4.  Change deprecated Float.to_string

### DIFF
--- a/lib/crutches/integer.ex
+++ b/lib/crutches/integer.ex
@@ -37,7 +37,7 @@ defmodule Crutches.Integer do
   def is_prime?(int) do
     is_prime?(int, 2, :math.sqrt(int))
   end
-  def is_prime?(int, divisor, limit) when divisor > limit, do: true
+  def is_prime?(_int, divisor, limit) when divisor > limit, do: true
   def is_prime?(int, divisor, limit) do
     cond do
       rem(int, divisor) === 0 -> false

--- a/lib/crutches/string.ex
+++ b/lib/crutches/string.ex
@@ -2,9 +2,6 @@ defmodule Crutches.String do
   alias Crutches.Option
   import String, only: [
     replace: 3,
-    downcase: 1,
-    split: 2,
-    capitalize: 1,
     slice: 2,
     strip: 1
   ]
@@ -41,27 +38,27 @@ defmodule Crutches.String do
       ["UsersSection.Commission.Department", "users_section/commission/department"],
 
   """
-  defdelegate underscore(string), to: Mix.Utils
+  defdelegate underscore(string), to: Macro
 
   @doc ~S"""
   Converts `string` to CamelCase.
 
   ## Examples
 
-      iex> String.camelize("product")
+      iex> Macro.camelize("product")
       "Product"
 
-      iex> String.camelize("special_guest")
+      iex> Macro.camelize("special_guest")
       "SpecialGuest"
 
-      iex> String.camelize("application_controller")
+      iex> Macro.camelize("application_controller")
       "ApplicationController"
 
-      iex> String.camelize("area51_controller")
+      iex> Macro.camelize("area51_controller")
       "Area51Controller"
 
   """
-  defdelegate camelize(string), to: Mix.Utils
+  defdelegate camelize(string), to: Macro
 
   # Access
 

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Crutches.Mixfile do
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps,
+     deps: deps(),
      description: "An Elixir toolbelt freely inspired from Ruby's ActiveSupport",
      package: [maintainers: ["Michael Wood", "Kash Nouroozi", "Maurizio Del Corno",
                               "nawns", "Laurens Duijvesteijn", "Joel Meador",


### PR DESCRIPTION
After upgrading to Elixir 1.4 I was seeing lots of warnings in the development log.  This pull request removes all of them, with all tests still passing.  

Thanks for the lib!

```
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:10

Compiling 2 files (.ex)
warning: unused import String.capitalize/1
  lib/crutches/string.ex:3

warning: unused import String.downcase/1
  lib/crutches/string.ex:3

warning: unused import String.split/2
  lib/crutches/string.ex:3

warning: the variable "fract_num" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/crutches/format/number.ex:712

.................................................................................................warning: Mix.Utils.camelize/1 is deprecated, use Macro.camelize/1 instead
  (mix) lib/mix/utils.ex:250: Mix.Utils.camelize/1
  (for doctest at) lib/crutches/string.ex:60: Crutches.StringTest."test doc at Crutches.String.camelize/1 (4)"/1
  (ex_unit) lib/ex_unit/runner.ex:302: ExUnit.Runner.exec_test/1
  (stdlib) timer.erl:166: :timer.tc/1
  (ex_unit) lib/ex_unit/runner.ex:250: anonymous fn/3 in ExUnit.Runner.spawn_test/3

....warning: Mix.Utils.camelize/1 is deprecated, use Macro.camelize/1 instead
  (mix) lib/mix/utils.ex:250: Mix.Utils.camelize/1
  (for doctest at) lib/crutches/string.ex:51: Crutches.StringTest."test doc at Crutches.String.camelize/1 (1)"/1
  (ex_unit) lib/ex_unit/runner.ex:302: ExUnit.Runner.exec_test/1
  (stdlib) timer.erl:166: :timer.tc/1
  (ex_unit) lib/ex_unit/runner.ex:250: anonymous fn/3 in ExUnit.Runner.spawn_test/3

..warning: Mix.Utils.underscore/1 is deprecated, use Macro.underscore/1 instead
  (mix) lib/mix/utils.ex:244: Mix.Utils.underscore/1
  (for doctest at) lib/crutches/string.ex:27: Crutches.StringTest."test doc at Crutches.String.underscore/1 (29)"/1
  (ex_unit) lib/ex_unit/runner.ex:302: ExUnit.Runner.exec_test/1
  (stdlib) timer.erl:166: :timer.tc/1
  (ex_unit) lib/ex_unit/runner.ex:250: anonymous fn/3 in ExUnit.Runner.spawn_test/3

..warning: Mix.Utils.camelize/1 is deprecated, use Macro.camelize/1 instead
  (mix) lib/mix/utils.ex:250: Mix.Utils.camelize/1
  (for doctest at) lib/crutches/string.ex:57: Crutches.StringTest."test doc at Crutches.String.camelize/1 (3)"/1
  (ex_unit) lib/ex_unit/runner.ex:302: ExUnit.Runner.exec_test/1
  (stdlib) timer.erl:166: :timer.tc/1
  (ex_unit) lib/ex_unit/runner.ex:250: anonymous fn/3 in ExUnit.Runner.spawn_test/3

......warning: Mix.Utils.underscore/1 is deprecated, use Macro.underscore/1 instead
  (mix) lib/mix/utils.ex:244: Mix.Utils.underscore/1
  (for doctest at) lib/crutches/string.ex:36: Crutches.StringTest."test doc at Crutches.String.underscore/1 (32)"/1
  (ex_unit) lib/ex_unit/runner.ex:302: ExUnit.Runner.exec_test/1
  (stdlib) timer.erl:166: :timer.tc/1
  (ex_unit) lib/ex_unit/runner.ex:250: anonymous fn/3 in ExUnit.Runner.spawn_test/3

.warning: Mix.Utils.underscore/1 is deprecated, use Macro.underscore/1 instead
  (mix) lib/mix/utils.ex:244: Mix.Utils.underscore/1
  (for doctest at) lib/crutches/string.ex:30: Crutches.StringTest."test doc at Crutches.String.underscore/1 (30)"/1
  (ex_unit) lib/ex_unit/runner.ex:302: ExUnit.Runner.exec_test/1
  (stdlib) timer.erl:166: :timer.tc/1
  (ex_unit) lib/ex_unit/runner.ex:250: anonymous fn/3 in ExUnit.Runner.spawn_test/3

..warning: Mix.Utils.underscore/1 is deprecated, use Macro.underscore/1 instead
  (mix) lib/mix/utils.ex:244: Mix.Utils.underscore/1
  (for doctest at) lib/crutches/string.ex:33: Crutches.StringTest."test doc at Crutches.String.underscore/1 (31)"/1
  (ex_unit) lib/ex_unit/runner.ex:302: ExUnit.Runner.exec_test/1
  (stdlib) timer.erl:166: :timer.tc/1
  (ex_unit) lib/ex_unit/runner.ex:250: anonymous fn/3 in ExUnit.Runner.spawn_test/3

........warning: Mix.Utils.camelize/1 is deprecated, use Macro.camelize/1 instead
  (mix) lib/mix/utils.ex:250: Mix.Utils.camelize/1
  (for doctest at) lib/crutches/string.ex:54: Crutches.StringTest."test doc at Crutches.String.camelize/1 (2)"/1
  (ex_unit) lib/ex_unit/runner.ex:302: ExUnit.Runner.exec_test/1
  (stdlib) timer.erl:166: :timer.tc/1
  (ex_unit) lib/ex_unit/runner.ex:250: anonymous fn/3 in ExUnit.Runner.spawn_test/3

.warning: Mix.Utils.underscore/1 is deprecated, use Macro.underscore/1 instead
  (mix) lib/mix/utils.ex:244: Mix.Utils.underscore/1
  test/crutches/string_test.exs:8: anonymous fn/1 in Crutches.StringTest.compare_underscored_camel/1
  (elixir) lib/enum.ex:645: Enum."-each/2-lists^foreach/1-0-"/2
  (elixir) lib/enum.ex:645: Enum.each/2
  test/crutches/string_test.exs:29: Crutches.StringTest."test camel_with_module_to_underscore_with_slash"/1

warning: Mix.Utils.underscore/1 is deprecated, use Macro.underscore/1 instead
  (mix) lib/mix/utils.ex:244: Mix.Utils.underscore/1
  test/crutches/string_test.exs:8: anonymous fn/1 in Crutches.StringTest.compare_underscored_camel/1
  (elixir) lib/enum.ex:645: Enum."-each/2-lists^foreach/1-0-"/2
  (elixir) lib/enum.ex:645: Enum.each/2
  test/crutches/string_test.exs:29: Crutches.StringTest."test camel_with_module_to_underscore_with_slash"/1

warning: Mix.Utils.underscore/1 is deprecated, use Macro.underscore/1 instead
  (mix) lib/mix/utils.ex:244: Mix.Utils.underscore/1
  test/crutches/string_test.exs:8: anonymous fn/1 in Crutches.StringTest.compare_underscored_camel/1
  (elixir) lib/enum.ex:645: Enum."-each/2-lists^foreach/1-0-"/2
  (elixir) lib/enum.ex:645: Enum.each/2
  test/crutches/string_test.exs:29: Crutches.StringTest."test camel_with_module_to_underscore_with_slash"/1

..warning: Mix.Utils.underscore/1 is deprecated, use Macro.underscore/1 instead
  (mix) lib/mix/utils.ex:244: Mix.Utils.underscore/1
  test/crutches/string_test.exs:8: anonymous fn/1 in Crutches.StringTest.compare_underscored_camel/1
  (elixir) lib/enum.ex:645: Enum."-each/2-lists^foreach/1-0-"/2
  (elixir) lib/enum.ex:645: Enum.each/2
  test/crutches/string_test.exs:20: Crutches.StringTest."test camel_to_underscore_without_reverse"/1

warning: Mix.Utils.underscore/1 is deprecated, use Macro.underscore/1 instead
  (mix) lib/mix/utils.ex:244: Mix.Utils.underscore/1
  test/crutches/string_test.exs:8: anonymous fn/1 in Crutches.StringTest.compare_underscored_camel/1
  (elixir) lib/enum.ex:645: Enum."-each/2-lists^foreach/1-0-"/2
  (elixir) lib/enum.ex:645: Enum.each/2
  test/crutches/string_test.exs:20: Crutches.StringTest."test camel_to_underscore_without_reverse"/1

warning: Mix.Utils.underscore/1 is deprecated, use Macro.underscore/1 instead
  (mix) lib/mix/utils.ex:244: Mix.Utils.underscore/1
  test/crutches/string_test.exs:8: anonymous fn/1 in Crutches.StringTest.compare_underscored_camel/1
  (elixir) lib/enum.ex:645: Enum."-each/2-lists^foreach/1-0-"/2
  (elixir) lib/enum.ex:645: Enum.each/2
  test/crutches/string_test.exs:20: Crutches.StringTest."test camel_to_underscore_without_reverse"/1

warning: Mix.Utils.underscore/1 is deprecated, use Macro.underscore/1 instead
  (mix) lib/mix/utils.ex:244: Mix.Utils.underscore/1
  test/crutches/string_test.exs:8: anonymous fn/1 in Crutches.StringTest.compare_underscored_camel/1
  (elixir) lib/enum.ex:645: Enum."-each/2-lists^foreach/1-0-"/2
  (elixir) lib/enum.ex:645: Enum.each/2
  test/crutches/string_test.exs:20: Crutches.StringTest."test camel_to_underscore_without_reverse"/1

warning: Mix.Utils.underscore/1 is deprecated, use Macro.underscore/1 instead
  (mix) lib/mix/utils.ex:244: Mix.Utils.underscore/1
  test/crutches/string_test.exs:8: anonymous fn/1 in Crutches.StringTest.compare_underscored_camel/1
  (elixir) lib/enum.ex:645: Enum."-each/2-lists^foreach/1-0-"/2
  (elixir) lib/enum.ex:645: Enum.each/2
  test/crutches/string_test.exs:20: Crutches.StringTest."test camel_to_underscore_without_reverse"/1

...warning: Float.to_string/2 is deprecated, use :erlang.float_to_binary/2 instead
  (elixir) lib/float.ex:414: Float.to_string/2
  (crutches) lib/crutches/format/number.ex:522: Crutches.Format.Number.as_percentage/2
  (for doctest at) lib/crutches/format/number.ex:477: Crutches.Format.NumberTest."test doc at Crutches.Format.Number.as_percentage/2 (57)"/1
  (ex_unit) lib/ex_unit/runner.ex:302: ExUnit.Runner.exec_test/1
  (stdlib) timer.erl:166: :timer.tc/1

warning: Float.to_string/2 is deprecated, use :erlang.float_to_binary/2 instead
  (elixir) lib/float.ex:414: Float.to_string/2
  (crutches) lib/crutches/format/number.ex:415: Crutches.Format.Number.as_currency/2
  (for doctest at) lib/crutches/format/number.ex:361: Crutches.Format.NumberTest."test doc at Crutches.Format.Number.as_currency/2 (3)"/1
  (ex_unit) lib/ex_unit/runner.ex:302: ExUnit.Runner.exec_test/1
  (stdlib) timer.erl:166: :timer.tc/1



  1) test doc at Crutches.Format.Number.as_rounded/2 (73) (Crutches.Format.NumberTest)
     test/crutches/format/number_test.exs:4
     Doctest failed
     code: Number.as_rounded(111.2345) === "111.235"
     left: "111.234"
     stacktrace:
       lib/crutches/format/number.ex:104: Crutches.Format.Number (module)

.......warning: Float.to_string/2 is deprecated, use :erlang.float_to_binary/2 instead
  (elixir) lib/float.ex:414: Float.to_string/2
  (crutches) lib/crutches/format/number.ex:415: Crutches.Format.Number.as_currency/2
  (for doctest at) lib/crutches/format/number.ex:358: Crutches.Format.NumberTest."test doc at Crutches.Format.Number.as_currency/2 (2)"/1
  (ex_unit) lib/ex_unit/runner.ex:302: ExUnit.Runner.exec_test/1
  (stdlib) timer.erl:166: :timer.tc/1

......warning: Float.to_string/2 is deprecated, use :erlang.float_to_binary/2 instead
  (elixir) lib/float.ex:414: Float.to_string/2
  (crutches) lib/crutches/format/number.ex:415: Crutches.Format.Number.as_currency/2
  (for doctest at) lib/crutches/format/number.ex:376: Crutches.Format.NumberTest."test doc at Crutches.Format.Number.as_currency/2 (8)"/1
  (ex_unit) lib/ex_unit/runner.ex:302: ExUnit.Runner.exec_test/1
  (stdlib) timer.erl:166: :timer.tc/1

..warning: Float.to_string/2 is deprecated, use :erlang.float_to_binary/2 instead
  (elixir) lib/float.ex:414: Float.to_string/2
  (crutches) lib/crutches/format/number.ex:415: Crutches.Format.Number.as_currency/2
  (for doctest at) lib/crutches/format/number.ex:373: Crutches.Format.NumberTest."test doc at Crutches.Format.Number.as_currency/2 (7)"/1
  (ex_unit) lib/ex_unit/runner.ex:302: ExUnit.Runner.exec_test/1
  (stdlib) timer.erl:166: :timer.tc/1

....warning: Float.to_string/2 is deprecated, use :erlang.float_to_binary/2 instead
  (elixir) lib/float.ex:414: Float.to_string/2
  (crutches) lib/crutches/format/number.ex:522: Crutches.Format.Number.as_percentage/2
  (for doctest at) lib/crutches/format/number.ex:468: Crutches.Format.NumberTest."test doc at Crutches.Format.Number.as_percentage/2 (54)"/1
  (ex_unit) lib/ex_unit/runner.ex:302: ExUnit.Runner.exec_test/1
  (stdlib) timer.erl:166: :timer.tc/1

...................warning: Float.to_string/2 is deprecated, use :erlang.float_to_binary/2 instead
  (elixir) lib/float.ex:414: Float.to_string/2
  (crutches) lib/crutches/format/number.ex:522: Crutches.Format.Number.as_percentage/2
  (for doctest at) lib/crutches/format/number.ex:486: Crutches.Format.NumberTest."test doc at Crutches.Format.Number.as_percentage/2 (60)"/1
  (ex_unit) lib/ex_unit/runner.ex:302: ExUnit.Runner.exec_test/1
  (stdlib) timer.erl:166: :timer.tc/1

........warning: Float.to_string/2 is deprecated, use :erlang.float_to_binary/2 instead
  (elixir) lib/float.ex:414: Float.to_string/2
  (crutches) lib/crutches/format/number.ex:415: Crutches.Format.Number.as_currency/2
  (for doctest at) lib/crutches/format/number.ex:355: Crutches.Format.NumberTest."test doc at Crutches.Format.Number.as_currency/2 (1)"/1
  (ex_unit) lib/ex_unit/runner.ex:302: ExUnit.Runner.exec_test/1
  (stdlib) timer.erl:166: :timer.tc/1

........warning: Float.to_string/2 is deprecated, use :erlang.float_to_binary/2 instead
  (elixir) lib/float.ex:414: Float.to_string/2
  (crutches) lib/crutches/format/number.ex:522: Crutches.Format.Number.as_percentage/2
  (for doctest at) lib/crutches/format/number.ex:474: Crutches.Format.NumberTest."test doc at Crutches.Format.Number.as_percentage/2 (56)"/1
  (ex_unit) lib/ex_unit/runner.ex:302: ExUnit.Runner.exec_test/1
  (stdlib) timer.erl:166: :timer.tc/1

.....warning: Float.to_string/2 is deprecated, use :erlang.float_to_binary/2 instead
  (elixir) lib/float.ex:414: Float.to_string/2
  (crutches) lib/crutches/format/number.ex:415: Crutches.Format.Number.as_currency/2
  (for doctest at) lib/crutches/format/number.ex:364: Crutches.Format.NumberTest."test doc at Crutches.Format.Number.as_currency/2 (4)"/1
  (ex_unit) lib/ex_unit/runner.ex:302: ExUnit.Runner.exec_test/1
  (stdlib) timer.erl:166: :timer.tc/1

.....warning: Float.to_string/2 is deprecated, use :erlang.float_to_binary/2 instead
  (elixir) lib/float.ex:414: Float.to_string/2
  (crutches) lib/crutches/format/number.ex:522: Crutches.Format.Number.as_percentage/2
  (for doctest at) lib/crutches/format/number.ex:480: Crutches.Format.NumberTest."test doc at Crutches.Format.Number.as_percentage/2 (58)"/1
  (ex_unit) lib/ex_unit/runner.ex:302: ExUnit.Runner.exec_test/1
  (stdlib) timer.erl:166: :timer.tc/1

..warning: Float.to_string/2 is deprecated, use :erlang.float_to_binary/2 instead
  (elixir) lib/float.ex:414: Float.to_string/2
  (crutches) lib/crutches/format/number.ex:522: Crutches.Format.Number.as_percentage/2
  (for doctest at) lib/crutches/format/number.ex:471: Crutches.Format.NumberTest."test doc at Crutches.Format.Number.as_percentage/2 (55)"/1
  (ex_unit) lib/ex_unit/runner.ex:302: ExUnit.Runner.exec_test/1
  (stdlib) timer.erl:166: :timer.tc/1

.......warning: Float.to_string/2 is deprecated, use :erlang.float_to_binary/2 instead
  (elixir) lib/float.ex:414: Float.to_string/2
  (crutches) lib/crutches/format/number.ex:415: Crutches.Format.Number.as_currency/2
  (for doctest at) lib/crutches/format/number.ex:370: Crutches.Format.NumberTest."test doc at Crutches.Format.Number.as_currency/2 (6)"/1
  (ex_unit) lib/ex_unit/runner.ex:302: ExUnit.Runner.exec_test/1
  (stdlib) timer.erl:166: :timer.tc/1

.....warning: Float.to_string/2 is deprecated, use :erlang.float_to_binary/2 instead
  (elixir) lib/float.ex:414: Float.to_string/2
  (crutches) lib/crutches/format/number.ex:522: Crutches.Format.Number.as_percentage/2
  (for doctest at) lib/crutches/format/number.ex:465: Crutches.Format.NumberTest."test doc at Crutches.Format.Number.as_percentage/2 (53)"/1
  (ex_unit) lib/ex_unit/runner.ex:302: ExUnit.Runner.exec_test/1
  (stdlib) timer.erl:166: :timer.tc/1

...

Finished in 0.7 seconds
210 tests, 1 failure
```